### PR TITLE
Fix in AsseticServiceProvider

### DIFF
--- a/src/Barryvdh/Assetic/AsseticServiceProvider.php
+++ b/src/Barryvdh/Assetic/AsseticServiceProvider.php
@@ -46,7 +46,7 @@ class AsseticServiceProvider extends ServiceProvider {
         $app['assetic'] = $app->share(function () use ($app) {
                 $app['assetic.path_to_web'] = $app['config']->get('laravel-assetic::config.path_to_web');
                 if( $app['config']->has('laravel-assetic::config.path_to_source')){
-                    $app['assetic.path_to_source'] = $app['config']->get('laravel-assetic::config.options.path_to_source');
+                    $app['assetic.path_to_source'] = $app['config']->get('laravel-assetic::config.path_to_source');
                 }
                 $app['assetic.options'] = $app['config']->get('laravel-assetic::config.options');
 


### PR DESCRIPTION
There was a typo - when `config.path_to_source` was set value of `config.options.path_to_source` was assigned to `$app['assetic.path_to_source']`.
