### PR TITLE
fixed AssetCollection compatibility issue

### DIFF
--- a/src/Barryvdh/Assetic/CheckedAssetWriter.php
+++ b/src/Barryvdh/Assetic/CheckedAssetWriter.php
@@ -51,7 +51,7 @@ class CheckedAssetWriter extends AssetWriter
                     $asset->getValues()
                 );
 
-            if(!file_exists($path) || filemtime($path) <= $asset->getLastModified()){
+            if (!is_dir($path) && (!file_exists($path) || filemtime($path) <= $asset->getLastModified())){
                 static::write(
                     $path,
                     $asset->dump()


### PR DESCRIPTION
I had some problemas while using  an asset manager config as shown bellow.

```
 'asset_manager' => function(AssetManager $am){                               
     $css = new AssetCollection(array(                                        
           new FileAsset(base_path().'/assets/css/dev.css'),                        
           new FileAsset(base_path().'/assets/css/project.css'),             
     ));                                                                      
     $scripts = new AssetCollection(array(                                    
         new GlobAsset(base_path().'/assets/js/libs/*'),                      
         new GlobAsset(base_path().'/assets/js/*')                            
     ));                                                                      

     $am->set('base_css', $css);                                              
     $am->set('base_js', $scripts);                                           
 },
```

CheckedAssetWriter was trying to write to a folder instead of the files. Fixed this issue by preventing writing text content directly into folders.
